### PR TITLE
Fixes #26 - RemoveTcpFromDataSource

### DIFF
--- a/src/NuGet.Services.Work.Facts/Helpers/SqlConnectionStringBuilderExtensionsFacts.cs
+++ b/src/NuGet.Services.Work.Facts/Helpers/SqlConnectionStringBuilderExtensionsFacts.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Data.SqlClient
+{
+    public class SqlConnectionStringBuilderExtensionsFacts
+    {
+        [Fact]
+        public void TrimNetworkProtocolWithTcpColon()
+        {
+            // Arrange
+            var cstr = new SqlConnectionStringBuilder("Data Source=tcp:blahblah.database.windows.net;Initial Catalog=NuGetDB");
+
+            // Act
+            cstr.TrimNetworkProtocol();
+
+            // Assert
+            Assert.True(cstr.DataSource.Equals("blahblah.database.windows.net"));
+            Assert.True(cstr.InitialCatalog.Equals("NuGetDB"));
+        }
+
+        [Fact]
+        public void TrimNetworkProtocolWithoutNetworkProtocol()
+        {
+            // Arrange
+            var cstr = new SqlConnectionStringBuilder("Data Source=blahblah.database.windows.net;Initial Catalog=NuGetDB");
+
+            // Act
+            cstr.TrimNetworkProtocol();
+
+            // Assert
+            Assert.True(cstr.DataSource.Equals("blahblah.database.windows.net"));
+            Assert.True(cstr.InitialCatalog.Equals("NuGetDB"));
+        }
+    }
+}

--- a/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
+++ b/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
@@ -152,6 +152,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Common\AssertEx.cs" />
+    <Compile Include="Helpers\SqlConnectionStringBuilderExtensionsFacts.cs" />
     <Compile Include="Infrastructure\JobRunnerFacts.cs" />
     <Compile Include="InvocationPayloadSerializerFacts.cs" />
     <Compile Include="Models\DatabaseBackupMetadataFacts.cs" />

--- a/src/NuGet.Services.Work/Helpers/SqlConnectionStringBuilderExtensions.cs
+++ b/src/NuGet.Services.Work/Helpers/SqlConnectionStringBuilderExtensions.cs
@@ -41,5 +41,15 @@ namespace System.Data.SqlClient
             await c.OpenAsync().ConfigureAwait(continueOnCapturedContext: false);
             return c;
         }
+
+        public static void TrimNetworkProtocol(this SqlConnectionStringBuilder cstr)
+        {
+            int colonIndex = cstr.DataSource.IndexOf(':');
+            if(colonIndex > -1 && colonIndex < cstr.DataSource.Length)
+            {
+                var trimmedcstr = cstr.DataSource.Substring(colonIndex + 1);
+                cstr.DataSource = trimmedcstr;
+            }
+        }
     }
 }

--- a/src/NuGet.Services.Work/Jobs/ExportDatabaseJob.cs
+++ b/src/NuGet.Services.Work/Jobs/ExportDatabaseJob.cs
@@ -50,6 +50,8 @@ namespace NuGet.Services.Work.Jobs
                 throw new ArgumentNullException("One of the connection string parameters or the string itself is null");
             }
 
+            cstr.TrimNetworkProtocol();
+
             if (DestinationStorageAccountKey == null && DestinationStorageAccountName == null)
             {
                 var destinationCredentials = Config.Storage.Backup.Credentials;

--- a/src/NuGet.Services.Work/Jobs/ImportDatabaseJob.cs
+++ b/src/NuGet.Services.Work/Jobs/ImportDatabaseJob.cs
@@ -47,6 +47,8 @@ namespace NuGet.Services.Work.Jobs
                 throw new ArgumentNullException("One of the connection string parameters or the string itself is null");
             }
 
+            cstr.TrimNetworkProtocol();
+
             if (SourceStorageAccountName == null && SourceStorageAccountKey == null)
             {
                 var sourceCredentials = Config.Storage.Primary.Credentials;

--- a/src/NuGet.Services.Work/Jobs/SyncPackagesFromBackupJob.cs
+++ b/src/NuGet.Services.Work/Jobs/SyncPackagesFromBackupJob.cs
@@ -45,6 +45,8 @@ namespace NuGet.Services.Work.Jobs
             Source = Source ?? Config.Storage.Backup;
             Destination = Destination ?? Config.Storage.Primary;
 
+            PackageDatabase.TrimNetworkProtocol();
+
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(
                 String.IsNullOrEmpty(SourceContainerName) ? BlobContainerNames.Backups : SourceContainerName);
             DestinationContainer = Destination.CreateCloudBlobClient().GetContainerReference(


### PR DESCRIPTION
Fixes NuGet/NuGetApi/#26 - RemoveTcpFromDataSource
Trim the network protocol from the data source before connecting to it. Do this for the all the applicable jobs
