### PR TITLE
Fix NuGet/NuGetGallery#1904 by changing the default destination for backups

### DIFF
--- a/src/NuGet.Services.Work/Jobs/BackupPackageBlobsJob.cs
+++ b/src/NuGet.Services.Work/Jobs/BackupPackageBlobsJob.cs
@@ -65,7 +65,7 @@ namespace NuGet.Services.Work.Jobs
             // Load default data if not provided
             PackageDatabase = PackageDatabase ?? Config.Sql.GetConnectionString(KnownSqlConnection.Legacy);
             Source = Source ?? Config.Storage.Legacy;
-            Destination = Destination ?? Config.Storage.Backup;
+            Destination = Destination ?? Config.Storage.Legacy;
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(
                 String.IsNullOrEmpty(SourceContainerName) ? BlobContainerNames.LegacyPackages : SourceContainerName);
             DestinationContainer = Destination.CreateCloudBlobClient().GetContainerReference(


### PR DESCRIPTION
Fixes NuGet/NuGetGallery#1904

It's a complicated one, I know :).

For 3.0.0's prod deployment, I'll have the Backup storage account value set to the same value as Legacy.
