### PR TITLE
Change TransferBackupPackages to use Storage Legacy as the source and St...

### DIFF
--- a/src/NuGet.Services.Work/Jobs/TransferBackupPackagesJob.cs
+++ b/src/NuGet.Services.Work/Jobs/TransferBackupPackagesJob.cs
@@ -36,7 +36,7 @@ namespace NuGet.Services.Work.Jobs
 
         protected internal override async Task Execute()
         {
-            Source = Source ?? Config.Storage.Primary;
+            Source = Source ?? Config.Storage.Legacy;
             Destination = Destination ?? Config.Storage.Backup;
 
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(


### PR DESCRIPTION
Fixes NuGet/NuGetGallery#1913

Change TransferBackupPackages to use Storage Legacy as the source and Storage Backup as the destination
