### PR TITLE
Fix for #2106 : Before renaming backup to TempBackup, check if there is a 'TempBackup'. If so, drop it first

### DIFF
--- a/src/NuGet.Services.Work/Jobs/Models/Database.cs
+++ b/src/NuGet.Services.Work/Jobs/Models/Database.cs
@@ -19,6 +19,11 @@ namespace NuGet.Services.Work.Jobs.Models
         {
             return DatabaseBackup.Create(this);
         }
+
+        public override string ToString()
+        {
+            return String.Format("Name: {0}, Created Date: {1}, State: {2}", name, create_date, state);
+        }
     }
 
     public class DatabaseBackup {


### PR DESCRIPTION
Fix for #2106 : Before renaming backup to TempBackup,
check if there is a 'TempBackup'. If so, drop it first
