### PR TITLE
Adding 'ORDER BY' clause to Get DownloadFacts Query which uses TOP to achieve predicatable results

### DIFF
--- a/src/NuGet.Services.Work/Jobs/Stats/ReplicatePackageStatisticsJob.cs
+++ b/src/NuGet.Services.Work/Jobs/Stats/ReplicatePackageStatisticsJob.cs
@@ -96,6 +96,7 @@ namespace NuGet.Services.Work.Jobs
                     INNER JOIN Packages ON PackageStatistics.PackageKey = Packages.[Key] 
                     INNER JOIN PackageRegistrations ON PackageRegistrations.[Key] = Packages.PackageRegistrationKey 
                     WHERE PackageStatistics.[Key] > @originalKey 
+                    ORDER BY PackageStatistics.[Key]
                     ", new
                     {
                         originalKey,


### PR DESCRIPTION
This results in predictable results

Fixes NuGet/NuGetGallery#2152
