### PR TITLE
Fix NuGet/NuGetGallery#2151 by removing pre-mature optimization

### DIFF
--- a/src/NuGet.Services.Work.Database/Stored Procedures/work.DequeueInvocation.sql
+++ b/src/NuGet.Services.Work.Database/Stored Procedures/work.DequeueInvocation.sql
@@ -8,7 +8,7 @@ AS
 	WITH cte
 	AS (
 		SELECT TOP (1) *
-		FROM [work].ActiveInvocations WITH (rowlock, readpast)
+		FROM [work].ActiveInvocations
 		WHERE [NextVisibleAt] <= SYSUTCDATETIME() 
 			AND Complete = 0
 		ORDER BY [NextVisibleAt]


### PR DESCRIPTION
I was rowlocking wrong, I should've been tablelocking all the things.

Fixes NuGet/NuGetGallery#2151
