### PR TITLE
Update to latest service platform

### DIFF
--- a/src/JobHost/App.config
+++ b/src/JobHost/App.config
@@ -31,11 +31,27 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.50320.36" newVersion="2.8.50320.36" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/JobHost/App.config
+++ b/src/JobHost/App.config
@@ -6,36 +6,24 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.18.0" newVersion="4.2.18.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -50,8 +38,32 @@
         <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.23.0" newVersion="4.2.23.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/JobHost/JobHost.csproj
+++ b/src/JobHost/JobHost.csproj
@@ -34,8 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\packages\Autofac.3.3.0\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Autofac.3.5.0\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
@@ -65,11 +66,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.0-beta1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -78,16 +81,17 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -100,13 +104,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50320.36, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.50506.491, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.16-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -124,20 +132,23 @@
     </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\..\packages\Rx-Core.2.2.2\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Core.2.2.4\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.2\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.4\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq">
-      <HintPath>..\..\packages\Rx-Linq.2.2.2\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.2\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
@@ -147,10 +158,11 @@
     </Reference>
     <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.1\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.1\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/JobHost/JobHost.csproj
+++ b/src/JobHost/JobHost.csproj
@@ -13,6 +13,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>bc26c467</NuGetPackageImportStamp>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,14 +42,17 @@
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.1\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.1\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -76,10 +80,14 @@
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -87,11 +95,11 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -102,40 +110,43 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.8.50506.491, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.23-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.23-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
-    <Reference Include="PowerArgs">
-      <HintPath>..\..\packages\PowerArgs.2.0.4.0-preview\lib\net40\PowerArgs.dll</HintPath>
+    <Reference Include="PowerArgs, Version=2.0.6.1, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\PowerArgs.2.1.0-preview\lib\net40\PowerArgs.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -150,19 +161,21 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices">
-      <HintPath>..\..\packages\Rx-PlatformServices.2.2.2\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.4\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Spatial, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <HintPath>..\..\packages\System.Spatial.5.6.1\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.0-rc\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.0-rc\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -190,11 +203,6 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
@@ -203,4 +211,9 @@
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
 </Project>

--- a/src/JobHost/Program.cs
+++ b/src/JobHost/Program.cs
@@ -35,7 +35,7 @@ namespace NuGet.Services.Work.JobHost
 
         private static void WriteUsage()
         {
-            Console.WriteLine(ArgUsage.GetUsage<Arguments>());
+            ArgUsage.GenerateUsageFromTemplate<Arguments>().Write();
 
             Console.WriteLine();
             Console.WriteLine("Available jobs: ");

--- a/src/JobHost/packages.config
+++ b/src/JobHost/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.3.0" targetFramework="net45" />
+  <package id="Autofac" version="3.5.0" targetFramework="net45" />
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging" version="1.0.1304.0" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.0.1304.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.1" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
@@ -18,19 +18,20 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.1" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.16-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="PowerArgs" version="2.0.4.0-preview" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.2" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />

--- a/src/JobHost/packages.config
+++ b/src/JobHost/packages.config
@@ -4,36 +4,36 @@
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.23-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="PowerArgs" version="2.0.4.0-preview" targetFramework="net45" />
+  <package id="PowerArgs" version="2.1.0-preview" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Services.Work.Client/NuGet.Services.Work.Client.csproj
+++ b/src/NuGet.Services.Work.Client/NuGet.Services.Work.Client.csproj
@@ -58,30 +58,25 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\portable-net45+wp80+win8\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Platform.Client">
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.16-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.22-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Formatting">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\portable-wp8+netcore45+net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\portable-net40+sl4+win8+wp71\System.Net.Http.Primitives.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
@@ -90,6 +85,11 @@
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NuGet.Services.Work.Client/app.config
+++ b/src/NuGet.Services.Work.Client/app.config
@@ -1,11 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
 </configuration>

--- a/src/NuGet.Services.Work.Client/packages.config
+++ b/src/NuGet.Services.Work.Client/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="portable-net45+wp80+win+MonoAndroid10+MonoTouch10" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="portable-net45+win+wp80" />
+  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="portable-net45+win+wp80" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="portable-net45+win+wp80" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" developmentDependency="true" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.16-r-master" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.22-r-master" targetFramework="portable-net45+win+wp80" />
 </packages>

--- a/src/NuGet.Services.Work.Cloud/NuGet.Services.Work.Cloud.ccproj
+++ b/src/NuGet.Services.Work.Cloud/NuGet.Services.Work.Cloud.ccproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>2.2</ProductVersion>
+    <ProductVersion>2.3</ProductVersion>
     <ProjectGuid>1d0164b6-92d4-455a-ac68-c30b61733748</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -16,6 +16,7 @@
     <TargetProfile>Local</TargetProfile>
     <PackageEnableRemoteDebugger>True</PackageEnableRemoteDebugger>
     <UseWebProjectPorts>False</UseWebProjectPorts>
+    <UseEmulatorExpressByDefault>False</UseEmulatorExpressByDefault>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -63,7 +64,7 @@
   <!-- Import the target files for this project template -->
   <PropertyGroup>
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
-    <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.2\</CloudExtensionsDir>
+    <CloudExtensionsDir Condition=" '$(CloudExtensionsDir)' == '' ">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Windows Azure Tools\2.3\</CloudExtensionsDir>
   </PropertyGroup>
   <Import Project="$(CloudExtensionsDir)Microsoft.WindowsAzure.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\..\NuGet.Cloud.targets" />

--- a/src/NuGet.Services.Work.Cloud/ServiceConfiguration.Cloud.cscfg
+++ b/src/NuGet.Services.Work.Cloud/ServiceConfiguration.Cloud.cscfg
@@ -1,40 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ServiceConfiguration serviceName="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="3" osVersion="*" schemaVersion="2013-10.2.2">
-    <Role name="NuGet.Services.Work">
-        <Instances count="1" />
-        <ConfigurationSettings>
-            <Setting name="Host.Name" value="nuget-local-0-work" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Primary" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Legacy" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Backup" value="UseDevelopmentStorage=true" />
-            
-            <!-- SQL Connections -->
-            <Setting name="Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0;Integrated Security=SSPI" />
-            <Setting name="Sql.Legacy" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
-            <Setting name="Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetWarehouse;Integrated Security=SSPI" />
-            
-            <Setting name="Work.PollInterval" value="00:00:15" />
-            <Setting name="Work.WorkersPerCore" value="2" />
-            <Setting name="Work.MaxWorkers" value="" />
-            
-            <Setting name="Http.BasePath" value="" />
-            <Setting name="Http.AdminKey" value="password" />
-            
-            <Setting name="LicenseReport.Service" value="" />
-            <Setting name="LicenseReport.Username" value="" />
-            <Setting name="LicenseReport.Password" value="" />
-            
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="" />
-        </ConfigurationSettings>
-        <Certificates>
-            <Certificate name="Microsoft.WindowsAzure.Plugins.RemoteAccess.PasswordEncryption" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-            <Certificate name="SSL" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-            <Certificate name="AzureManagement" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-        </Certificates>
-    </Role>
+<ServiceConfiguration serviceName="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="3" osVersion="*" schemaVersion="2014-01.2.3">
+  <Role name="NuGet.Services.Work">
+    <Instances count="1" />
+    <ConfigurationSettings>
+      <Setting name="Host.Name" value="nuget-local-0-work" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Primary" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Legacy" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Backup" value="UseDevelopmentStorage=true" />
+      <!-- SQL Connections -->
+      <Setting name="Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0;Integrated Security=SSPI" />
+      <Setting name="Sql.Legacy" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
+      <Setting name="Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetWarehouse;Integrated Security=SSPI" />
+      <Setting name="Work.PollInterval" value="00:00:15" />
+      <Setting name="Work.WorkersPerCore" value="2" />
+      <Setting name="Work.MaxWorkers" value="" />
+      <Setting name="Http.BasePath" value="" />
+      <Setting name="Http.AdminKey" value="password" />
+      <Setting name="LicenseReport.Service" value="" />
+      <Setting name="LicenseReport.Username" value="" />
+      <Setting name="LicenseReport.Password" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="" />
+    </ConfigurationSettings>
+    <Certificates>
+      <Certificate name="Microsoft.WindowsAzure.Plugins.RemoteAccess.PasswordEncryption" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+      <Certificate name="SSL" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+      <Certificate name="AzureManagement" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+    </Certificates>
+  </Role>
 </ServiceConfiguration>

--- a/src/NuGet.Services.Work.Cloud/ServiceConfiguration.Local.cscfg
+++ b/src/NuGet.Services.Work.Cloud/ServiceConfiguration.Local.cscfg
@@ -1,40 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ServiceConfiguration serviceName="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="3" osVersion="*" schemaVersion="2013-10.2.2">
-    <Role name="NuGet.Services.Work">
-        <Instances count="1" />
-        <ConfigurationSettings>
-            <Setting name="Host.Name" value="nuget-local-0-work" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Primary" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Legacy" value="UseDevelopmentStorage=true" />
-            <Setting name="Storage.Backup" value="UseDevelopmentStorage=true" />
-            
-            <!-- SQL Connections -->
-            <Setting name="Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0;Integrated Security=SSPI" />
-            <Setting name="Sql.Legacy" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
-            <Setting name="Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0-warehouse;Integrated Security=SSPI" />
-            
-            <Setting name="Work.PollInterval" value="00:00:15" />
-            <Setting name="Work.WorkersPerCore" value="2" />
-            <Setting name="Work.MaxWorkers" value="" />
-            
-            <Setting name="Http.BasePath" value="" />
-            <Setting name="Http.AdminKey" value="password" />
-            
-            <Setting name="LicenseReport.Service" value="" />
-            <Setting name="LicenseReport.Username" value="" />
-            <Setting name="LicenseReport.Password" value="" />
-            
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="" />
-            <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="" />
-        </ConfigurationSettings>
-        <Certificates>
-            <Certificate name="Microsoft.WindowsAzure.Plugins.RemoteAccess.PasswordEncryption" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-            <Certificate name="SSL" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-            <Certificate name="AzureManagement" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
-        </Certificates>
-    </Role>
+<ServiceConfiguration serviceName="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceConfiguration" osFamily="3" osVersion="*" schemaVersion="2014-01.2.3">
+  <Role name="NuGet.Services.Work">
+    <Instances count="1" />
+    <ConfigurationSettings>
+      <Setting name="Host.Name" value="nuget-local-0-work" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Primary" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Legacy" value="UseDevelopmentStorage=true" />
+      <Setting name="Storage.Backup" value="UseDevelopmentStorage=true" />
+      <!-- SQL Connections -->
+      <Setting name="Sql.Primary" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0;Integrated Security=SSPI" />
+      <Setting name="Sql.Legacy" value="Data Source=(LocalDB)\v11.0;Initial Catalog=NuGetGallery;Integrated Security=SSPI" />
+      <Setting name="Sql.Warehouse" value="Data Source=(LocalDB)\v11.0;Initial Catalog=nuget-local-0-warehouse;Integrated Security=SSPI" />
+      <Setting name="Work.PollInterval" value="00:00:15" />
+      <Setting name="Work.WorkersPerCore" value="2" />
+      <Setting name="Work.MaxWorkers" value="" />
+      <Setting name="Http.BasePath" value="" />
+      <Setting name="Http.AdminKey" value="password" />
+      <Setting name="LicenseReport.Service" value="" />
+      <Setting name="LicenseReport.Username" value="" />
+      <Setting name="LicenseReport.Password" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.Enabled" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountUsername" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountEncryptedPassword" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteAccess.AccountExpiration" value="" />
+      <Setting name="Microsoft.WindowsAzure.Plugins.RemoteForwarder.Enabled" value="" />
+    </ConfigurationSettings>
+    <Certificates>
+      <Certificate name="Microsoft.WindowsAzure.Plugins.RemoteAccess.PasswordEncryption" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+      <Certificate name="SSL" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+      <Certificate name="AzureManagement" thumbprint="1010101010101010101010101010101010101010" thumbprintAlgorithm="sha1" />
+    </Certificates>
+  </Role>
 </ServiceConfiguration>

--- a/src/NuGet.Services.Work.Cloud/ServiceDefinition.csdef
+++ b/src/NuGet.Services.Work.Cloud/ServiceDefinition.csdef
@@ -1,58 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<ServiceDefinition name="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2013-10.2.2">
-    <WorkerRole name="NuGet.Services.Work" vmsize="Medium">
-        <!-- Must be elevated to bind to ports under 1024 -->
-        <Runtime executionContext="elevated" />
-        <Imports>
-            <Import moduleName="Diagnostics" />
-            <Import moduleName="RemoteAccess" />
-            <Import moduleName="RemoteForwarder" />
-        </Imports>
-        <ConfigurationSettings>
-            <!-- The full name of the service host (i.e. nuget-int-0-work, nuget-prod-1-search, etc.) -->
-            <Setting name="Host.Name" />
-            <!-- The name of the service host -->
-            <Setting name="Storage.Primary" />
-            <Setting name="Storage.Legacy" />
-            <Setting name="Storage.Backup" />
-            
-            <!-- SQL Connections -->
-            <Setting name="Sql.Primary" />
-            <Setting name="Sql.Legacy" />
-            <Setting name="Sql.Warehouse" />
-            
-            <Setting name="Work.PollInterval" />
-            <Setting name="Work.WorkersPerCore" />
-            <Setting name="Work.MaxWorkers" />
-
-            <Setting name="Http.BasePath" />
-            <Setting name="Http.AdminKey" />
-            
-            <Setting name="LicenseReport.Service" />
-            <Setting name="LicenseReport.Username" />
-            <Setting name="LicenseReport.Password" />
-        </ConfigurationSettings>
-        <Certificates>
-            <Certificate name="SSL" permissionLevel="limitedOrElevated" storeLocation="LocalMachine" storeName="My" />
-            <Certificate name="AzureManagement" permissionLevel="limitedOrElevated" storeLocation="LocalMachine" storeName="My" />
-        </Certificates>
-        <LocalResources>
-            <LocalStorage name="Logs" cleanOnRoleRecycle="false" sizeInMB="2048" />
-            <LocalStorage name="Temp" cleanOnRoleRecycle="true" sizeInMB="2048" />
-        </LocalResources>
-        <Endpoints>
-            <InputEndpoint name="http" protocol="http" port="80" localPort="80" />
-            <InputEndpoint name="https" protocol="https" port="443" localPort="443" certificate="SSL" />
-            <InstanceInputEndpoint name="https-instance" protocol="tcp" localPort="443">
-                <AllocatePublicPortFrom>
-                    <FixedPortRange max="44399" min="44300" />
-                </AllocatePublicPortFrom>
-            </InstanceInputEndpoint>
-            <InstanceInputEndpoint name="http-instance" protocol="tcp" localPort="80">
-                <AllocatePublicPortFrom>
-                    <FixedPortRange max="8099" min="8000" />
-                </AllocatePublicPortFrom>
-            </InstanceInputEndpoint>
-        </Endpoints>
-    </WorkerRole>
+<ServiceDefinition name="NuGet.Services.Work.Cloud" xmlns="http://schemas.microsoft.com/ServiceHosting/2008/10/ServiceDefinition" schemaVersion="2014-01.2.3">
+  <WorkerRole name="NuGet.Services.Work" vmsize="Medium">
+    <!-- Must be elevated to bind to ports under 1024 -->
+    <Runtime executionContext="elevated" />
+    <Imports>
+      <Import moduleName="Diagnostics" />
+      <Import moduleName="RemoteAccess" />
+      <Import moduleName="RemoteForwarder" />
+    </Imports>
+    <ConfigurationSettings>
+      <!-- The full name of the service host (i.e. nuget-int-0-work, nuget-prod-1-search, etc.) -->
+      <Setting name="Host.Name" />
+      <!-- The name of the service host -->
+      <Setting name="Storage.Primary" />
+      <Setting name="Storage.Legacy" />
+      <Setting name="Storage.Backup" />
+      <!-- SQL Connections -->
+      <Setting name="Sql.Primary" />
+      <Setting name="Sql.Legacy" />
+      <Setting name="Sql.Warehouse" />
+      <Setting name="Work.PollInterval" />
+      <Setting name="Work.WorkersPerCore" />
+      <Setting name="Work.MaxWorkers" />
+      <Setting name="Http.BasePath" />
+      <Setting name="Http.AdminKey" />
+      <Setting name="LicenseReport.Service" />
+      <Setting name="LicenseReport.Username" />
+      <Setting name="LicenseReport.Password" />
+    </ConfigurationSettings>
+    <Certificates>
+      <Certificate name="SSL" permissionLevel="limitedOrElevated" storeLocation="LocalMachine" storeName="My" />
+      <Certificate name="AzureManagement" permissionLevel="limitedOrElevated" storeLocation="LocalMachine" storeName="My" />
+    </Certificates>
+    <LocalResources>
+      <LocalStorage name="Logs" cleanOnRoleRecycle="false" sizeInMB="2048" />
+      <LocalStorage name="Temp" cleanOnRoleRecycle="true" sizeInMB="2048" />
+    </LocalResources>
+    <Endpoints>
+      <InputEndpoint name="http" protocol="http" port="80" localPort="80" />
+      <InputEndpoint name="https" protocol="https" port="443" localPort="443" certificate="SSL" />
+      <InstanceInputEndpoint name="https-instance" protocol="tcp" localPort="443">
+        <AllocatePublicPortFrom>
+          <FixedPortRange max="44399" min="44300" />
+        </AllocatePublicPortFrom>
+      </InstanceInputEndpoint>
+      <InstanceInputEndpoint name="http-instance" protocol="tcp" localPort="80">
+        <AllocatePublicPortFrom>
+          <FixedPortRange max="8099" min="8000" />
+        </AllocatePublicPortFrom>
+      </InstanceInputEndpoint>
+    </Endpoints>
+  </WorkerRole>
 </ServiceDefinition>

--- a/src/NuGet.Services.Work.Facts/Infrastructure/JobRunnerFacts.cs
+++ b/src/NuGet.Services.Work.Facts/Infrastructure/JobRunnerFacts.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Moq;
 using NuGet.Services.Work.Monitoring;
 using Xunit;
-using Xunit.Extensions;
 using NuGet.Services.Work.Models;
 
 namespace NuGet.Services.Work.Infrastructure

--- a/src/NuGet.Services.Work.Facts/Infrastructure/JobRunnerFacts.cs
+++ b/src/NuGet.Services.Work.Facts/Infrastructure/JobRunnerFacts.cs
@@ -1,14 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Queue;
 using Moq;
-using NuGet.Services.Configuration;
 using NuGet.Services.Work.Monitoring;
-using NuGet.Services.Storage;
 using Xunit;
 using Xunit.Extensions;
 using NuGet.Services.Work.Models;
@@ -389,7 +384,6 @@ namespace NuGet.Services.Work.Infrastructure
 
             public Mock<InvocationQueue> MockQueue { get; private set; }
             public Mock<JobDispatcher> MockDispatcher { get; private set; }
-            public Mock<StorageHub> MockStorage { get; private set; }
             public VirtualClock VirtualClock { get; private set; }
 
             public InvocationState LastDispatched { get; private set; }
@@ -401,7 +395,6 @@ namespace NuGet.Services.Work.Infrastructure
                 // Arrange
                 Queue = (MockQueue = new Mock<InvocationQueue>()).Object;
                 Dispatcher = (MockDispatcher = new Mock<JobDispatcher>()).Object;
-                Storage = (MockStorage = new Mock<StorageHub>()).Object;
                 Clock = VirtualClock = new VirtualClock();
 
                 _skipDispatch = skipDispatch;

--- a/src/NuGet.Services.Work.Facts/InvocationPayloadSerializerFacts.cs
+++ b/src/NuGet.Services.Work.Facts/InvocationPayloadSerializerFacts.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NuGet.Services.Work
 {
@@ -26,14 +22,14 @@ namespace NuGet.Services.Work
         }
 
         [Theory]
-        [PropertyData("SimpleSerializationData")]
+        [MemberData("SimpleSerializationData")]
         public void SimpleSerialization(Dictionary<string, string> payload, string expectedJson)
         {
             Assert.Equal(expectedJson, InvocationPayloadSerializer.Serialize(payload));
         }
 
         [Theory]
-        [PropertyData("SimpleSerializationData")]
+        [MemberData("SimpleSerializationData")]
         public void SimpleDeserialization(Dictionary<string, string> expectedPayload, string json)
         {
             var deserialized = InvocationPayloadSerializer.Deserialize(json);

--- a/src/NuGet.Services.Work.Facts/Models/DatabaseBackupMetadataFacts.cs
+++ b/src/NuGet.Services.Work.Facts/Models/DatabaseBackupMetadataFacts.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NuGet.Services.Work.Jobs.Models;
+﻿using NuGet.Services.Work.Jobs.Models;
 using Xunit;
-using Xunit.Extensions;
 
 namespace NuGet.Services.Work.Models
 {

--- a/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
+++ b/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
@@ -39,8 +39,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\packages\Autofac.3.3.0\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Autofac.3.5.0\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
@@ -73,11 +74,13 @@
     <Reference Include="Microsoft.Owin.Testing">
       <HintPath>..\..\packages\Microsoft.Owin.Testing.3.0.0-alpha1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -86,16 +89,17 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -116,17 +120,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50320.36, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.50506.491, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.16-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.16-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.TestCommon, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -145,20 +149,23 @@
     </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\..\packages\Rx-Core.2.2.2\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Core.2.2.4\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.2\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.4\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq">
-      <HintPath>..\..\packages\Rx-Linq.2.2.2\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Reactive.PlatformServices">
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.2\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
@@ -168,10 +175,11 @@
     </Reference>
     <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.1\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.1\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
+++ b/src/NuGet.Services.Work.Facts/NuGet.Services.Work.Facts.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.core.2.0.0-beta-build2650\build\portable-net45+win+wpa81+wp80\xunit.core.props" Condition="Exists('..\..\packages\xunit.core.2.0.0-beta-build2650\build\portable-net45+win+wpa81+wp80\xunit.core.props')" />
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.props" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -18,7 +19,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <NuGetPackageImportStamp>937ae555</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>e42a885a</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -46,14 +47,17 @@
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.1\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.1\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -71,8 +75,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.0-beta1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Testing">
-      <HintPath>..\..\packages\Microsoft.Owin.Testing.3.0.0-alpha1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Testing, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Testing.3.0.0-beta1\lib\net45\Microsoft.Owin.Testing.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -84,10 +89,14 @@
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -95,18 +104,18 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Management.Sql, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.WindowsAzure.Management.Sql, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql.0.9.14-preview\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql.1.2.0\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -118,23 +127,23 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.8.50506.491, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.23-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.23-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.TestCommon, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.TestCommon, Version=3.0.22.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.TestCommon.3.0.16-r-master\lib\net45\NuGet.Services.TestCommon.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.TestCommon.3.0.22-r-master\lib\net45\NuGet.Services.TestCommon.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -144,15 +153,17 @@
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -167,30 +178,35 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.PlatformServices">
-      <HintPath>..\..\packages\Rx-PlatformServices.2.2.2\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Reactive.PlatformServices, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.4\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Spatial, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <HintPath>..\..\packages\System.Spatial.5.6.1\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.0-rc\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.0-rc\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.0-beta-build2650\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert">
+      <HintPath>..\..\packages\xunit.assert.2.0.0-beta-build2650\lib\portable-net45+win+wpa81+wp80\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core">
+      <HintPath>..\..\packages\xunit.core.2.0.0-beta-build2650\lib\portable-net45+win+wpa81+wp80\xunit.core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -225,17 +241,18 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.props'))" />
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets'))" />
+    <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0-beta-build2650\build\portable-net45+win+wpa81+wp80\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0-beta-build2650\build\portable-net45+win+wpa81+wp80\xunit.core.props'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
 </Project>

--- a/src/NuGet.Services.Work.Facts/app.config
+++ b/src/NuGet.Services.Work.Facts/app.config
@@ -3,6 +3,22 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="msshrtmi" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="WindowsAzureTelemetryEvents" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="WindowsAzureEventSource" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
 			</dependentAssembly>
@@ -24,7 +40,7 @@
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.1.0.3" newVersion="2.1.0.3" />
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -64,15 +80,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.50320.36" newVersion="2.8.50320.36" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
@@ -85,6 +101,14 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NuGet.Services.Work.Facts/app.config
+++ b/src/NuGet.Services.Work.Facts/app.config
@@ -1,115 +1,107 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    <runtime>
+    	<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="msshrtmi" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="WindowsAzureTelemetryEvents" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="WindowsAzureEventSource" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-2.3.0.0" newVersion="2.3.0.0" />
+				<assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Core" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
+				<bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.WindowsAzure.Management.Sql" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+				<bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
 			</dependentAssembly>
 			<dependentAssembly>
 				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral" />
 				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
 			</dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.18.0" newVersion="4.2.18.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Interfaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Linq" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.4.0" newVersion="2.2.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+				<dependentAssembly>
+    					<assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-4.2.23.0" newVersion="4.2.23.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
+    			</dependentAssembly>
+    			<dependentAssembly>
+    					<assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
+    					<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+    			</dependentAssembly>
+    	</assemblyBinding>
+	</runtime>
 </configuration>

--- a/src/NuGet.Services.Work.Facts/packages.config
+++ b/src/NuGet.Services.Work.Facts/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.3.0" targetFramework="net45" />
+  <package id="Autofac" version="3.5.0" targetFramework="net45" />
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging" version="1.0.1304.0" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.0.1304.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.1" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
@@ -19,22 +19,22 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Testing" version="3.0.0-alpha1" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Management.Sql" version="0.9.14-preview" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.1" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.16-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.16-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
   <package id="NuGet.Services.TestCommon" version="3.0.16-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.2" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.0" targetFramework="net45" />

--- a/src/NuGet.Services.Work.Facts/packages.config
+++ b/src/NuGet.Services.Work.Facts/packages.config
@@ -4,41 +4,43 @@
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
-  <package id="Microsoft.Owin.Testing" version="3.0.0-alpha1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Testing" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Management.Sql" version="0.9.14-preview" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Management.Sql" version="1.2.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.TestCommon" version="3.0.16-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.TestCommon" version="3.0.22-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.0.0-beta-build2650" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0-beta-build2650" targetFramework="net45" />
+  <package id="xunit.assert" version="2.0.0-beta-build2650" targetFramework="net45" />
+  <package id="xunit.core" version="2.0.0-beta-build2650" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Services.Work/Api/Controllers/InvocationsController.cs
+++ b/src/NuGet.Services.Work/Api/Controllers/InvocationsController.cs
@@ -1,15 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using NuGet.Services.Http;
-using NuGet.Services.Work.Api.Models;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Models;
-using System.Net.Http;
 
 namespace NuGet.Services.Work.Api.Controllers
 {
@@ -17,12 +12,10 @@ namespace NuGet.Services.Work.Api.Controllers
     [Authorize(Roles = Roles.Admin)]
     public class InvocationsController : NuGetApiController
     {
-        public StorageHub Storage { get; private set; }
         public InvocationQueue Queue { get; private set; }
 
-        public InvocationsController(StorageHub storage, InvocationQueue queue)
+        public InvocationsController(InvocationQueue queue)
         {
-            Storage = storage;
             Queue = queue;
         }
 

--- a/src/NuGet.Services.Work/Api/Controllers/JobsController.cs
+++ b/src/NuGet.Services.Work/Api/Controllers/JobsController.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using NuGet.Services.Http;
-using NuGet.Services.Work.Api.Models;
-using NuGet.Services.Storage;
 
 namespace NuGet.Services.Work.Api.Controllers
 {
@@ -15,12 +11,10 @@ namespace NuGet.Services.Work.Api.Controllers
     [Authorize(Roles = Roles.Admin)]
     public class JobsController : NuGetApiController
     {
-        public StorageHub Storage { get; private set; }
         public InvocationQueue Queue { get; private set; }
 
-        public JobsController(StorageHub storage, InvocationQueue queue)
+        public JobsController(InvocationQueue queue)
         {
-            Storage = storage;
             Queue = queue;
         }
 

--- a/src/NuGet.Services.Work/Infrastructure/InvocationQueue.cs
+++ b/src/NuGet.Services.Work/Infrastructure/InvocationQueue.cs
@@ -375,7 +375,7 @@ namespace NuGet.Services.Work
             return ConnectAndQuery(@"
                 WITH cte AS (
                     SELECT *, ROW_NUMBER() OVER (PARTITION BY Job ORDER BY [UpdatedAt] DESC) AS rn
-	                FROM [work].Invocations
+                    FROM [work].Invocations
                 )
                 SELECT *
                 FROM cte

--- a/src/NuGet.Services.Work/Infrastructure/InvocationState.cs
+++ b/src/NuGet.Services.Work/Infrastructure/InvocationState.cs
@@ -1,13 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.WindowsAzure.Storage.Queue;
-using Microsoft.WindowsAzure.Storage.Table;
-using Newtonsoft.Json;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Models;
 
 namespace NuGet.Services.Work

--- a/src/NuGet.Services.Work/Infrastructure/JobDescription.cs
+++ b/src/NuGet.Services.Work/Infrastructure/JobDescription.cs
@@ -1,24 +1,14 @@
 ﻿using System;
-using System.Reflection;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using System.Linq.Expressions;
 using System.ComponentModel;
 using Microsoft.WindowsAzure.Storage.Table;
 using System.Diagnostics.Tracing;
 using System.ComponentModel.DataAnnotations.Schema;
-using NuGet.Services.Storage;
-using Autofac.Builder;
 
 namespace NuGet.Services.Work
 {
-    [Table("Jobs")]
-    public class JobDescription : AzureTableEntity
+    public class JobDescription
     {
-        public string Name { get { return PartitionKey; } set { PartitionKey = value; } }
+        public string Name { get; private set; }
         public string Description { get; set; }
         public Guid? EventProviderId { get; set; }
         public bool? Enabled { get; set; }
@@ -35,8 +25,8 @@ namespace NuGet.Services.Work
             : this(name, null, null, implementation) { }
 
         public JobDescription(string name, string description, Guid? eventProviderId, Type implementation)
-            : base(name, DateTimeOffset.UtcNow)
         {
+            Name = name;
             Description = description;
             EventProviderId = eventProviderId;
             Implementation = implementation;

--- a/src/NuGet.Services.Work/JobComponentsModule.cs
+++ b/src/NuGet.Services.Work/JobComponentsModule.cs
@@ -1,13 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Autofac;
+﻿using Autofac;
 using NuGet.Services.Configuration;
-using NuGet.Services.ServiceModel;
-using NuGet.Services.Storage;
-using NuGet.Services.Work.Monitoring;
 
 namespace NuGet.Services.Work
 {
@@ -44,7 +36,6 @@ namespace NuGet.Services.Work
                     .UsingConstructor(
                         typeof(Clock),
                         typeof(string),
-                        typeof(StorageHub),
                         typeof(ConfigurationHub))
                     .WithParameter(
                         new NamedParameter("instanceName", _instanceName));

--- a/src/NuGet.Services.Work/Jobs/Db/CopyDatabaseJob.cs
+++ b/src/NuGet.Services.Work/Jobs/Db/CopyDatabaseJob.cs
@@ -166,7 +166,6 @@ namespace NuGet.Services.Work.Jobs
                 Log.RenamingExistingCopyTarget(TargetDatabaseName, existingBackupName);
                 await sql.Databases.UpdateAsync(TargetServerName, TargetDatabaseName, new DatabaseUpdateParameters()
                 {
-                    CollationName = existingDb.CollationName,
                     Edition = existingDb.Edition,
                     Name = existingBackupName
                 });
@@ -185,7 +184,6 @@ namespace NuGet.Services.Work.Jobs
                 var restoreDb = await sql.Databases.GetAsync(TargetServerName, CopyName);
                 await sql.Databases.UpdateAsync(TargetServerName, CopyName, new DatabaseUpdateParameters()
                 {
-                    CollationName = restoreDb.Database.CollationName,
                     Edition = restoreDb.Database.Edition,
                     Name = TargetDatabaseName
                 });
@@ -208,7 +206,6 @@ namespace NuGet.Services.Work.Jobs
                     Log.RecoveringExistingCopy(existingBackupName, TargetDatabaseName);
                     await sql.Databases.UpdateAsync(TargetServerName, CopyName, new DatabaseUpdateParameters()
                     {
-                        CollationName = existingDb.CollationName,
                         Edition = existingDb.Edition,
                         Name = TargetDatabaseName
                     });

--- a/src/NuGet.Services.Work/Jobs/HandlePackageEditsJob.cs
+++ b/src/NuGet.Services.Work/Jobs/HandlePackageEditsJob.cs
@@ -16,7 +16,6 @@ using Dapper;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using NuGet.Services.Configuration;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Jobs.Models;
 
 namespace NuGet.Services.Work.Jobs
@@ -60,13 +59,11 @@ namespace NuGet.Services.Work.Jobs
         protected CloudBlobContainer SourceContainer { get; set; }
         protected CloudBlobContainer BackupsContainer { get; set; }
 
-        protected StorageHub Storage { get; set; }
         protected ConfigurationHub Config { get; set; }
         protected long MaxManifestSize { get; set; }
 
-        public HandlePackageEditsJob(StorageHub storage, ConfigurationHub config)
+        public HandlePackageEditsJob(ConfigurationHub config)
         {
-            Storage = storage;
             Config = config;
         }
 
@@ -75,8 +72,8 @@ namespace NuGet.Services.Work.Jobs
             // Load defaults
             MaxManifestSize = MaxAllowedManifestBytes ?? DefaultMaxAllowedManifestBytes;
             PackageDatabase = PackageDatabase ?? Config.Sql.GetConnectionString(KnownSqlConnection.Legacy);
-            Source = Source ?? Storage.Legacy.Account;
-            Backups = Backups ?? Storage.Backup.Account;
+            Source = Source ?? Config.Storage.Legacy;
+            Backups = Backups ?? Config.Storage.Backup;
             SourceContainer = Source.CreateCloudBlobClient().GetContainerReference(
                 String.IsNullOrEmpty(SourceContainerName) ? BlobContainerNames.LegacyPackages : SourceContainerName);
             BackupsContainer = Backups.CreateCloudBlobClient().GetContainerReference(

--- a/src/NuGet.Services.Work/Jobs/Stats/CreateWarehouseReportsJob.cs
+++ b/src/NuGet.Services.Work/Jobs/Stats/CreateWarehouseReportsJob.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 using System.Data.SqlClient;
@@ -9,7 +8,6 @@ using Dapper;
 using Microsoft.WindowsAzure.Storage;
 using NuGet.Services.Configuration;
 using Microsoft.WindowsAzure.Storage.Blob;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Helpers;
 using System.Data;
 using NuGet.Services.Client;

--- a/src/NuGet.Services.Work/Jobs/Storage/BackupPackageBlobsJob.cs
+++ b/src/NuGet.Services.Work/Jobs/Storage/BackupPackageBlobsJob.cs
@@ -3,17 +3,12 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.SqlClient;
 using System.Diagnostics.Tracing;
-using System.Globalization;
 using System.Linq;
-using System.Net;
-using System.Text;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using Dapper;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using NuGet.Services.Configuration;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Jobs.Models;
 
 namespace NuGet.Services.Work.Jobs
@@ -47,15 +42,13 @@ namespace NuGet.Services.Work.Jobs
         public bool RunInParallel { get; set; }
 
         protected ConfigurationHub Config { get; private set; }
-        protected StorageHub Storage { get; private set; }
-
+        
         protected CloudBlobContainer SourceContainer { get; private set; }
         protected CloudBlobContainer DestinationContainer { get; private set; }
 
-        public BackupPackageBlobsJob(ConfigurationHub config, StorageHub storage)
+        public BackupPackageBlobsJob(ConfigurationHub config)
         {
             Config = config;
-            Storage = storage;
         }
 
         protected internal override async Task Execute()

--- a/src/NuGet.Services.Work/LocalWorkService.cs
+++ b/src/NuGet.Services.Work/LocalWorkService.cs
@@ -10,7 +10,6 @@ using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
 using NuGet.Services.Configuration;
 using NuGet.Services.Hosting;
 using NuGet.Services.ServiceModel;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Models;
 using NuGet.Services.Work.Monitoring;
 
@@ -67,7 +66,6 @@ namespace NuGet.Services.Work
                     Container),
                 InvocationQueue.Null,
                 Container.Resolve<ConfigurationHub>(),
-                Container.Resolve<StorageHub>(),
                 Clock.RealClock);
 
             var invocation =

--- a/src/NuGet.Services.Work/Metadata/EmitMetadataBlobs.cs
+++ b/src/NuGet.Services.Work/Metadata/EmitMetadataBlobs.cs
@@ -1,29 +1,23 @@
-﻿using NuGet.Services.Metadata.Catalog;
-using NuGet.Services.Metadata.Catalog.Collecting;
+﻿using NuGet.Services.Metadata.Catalog.Collecting;
 using NuGet.Services.Metadata.Catalog.Persistence;
 using NuGet.Services.Configuration;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Tracing;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
-using NuGet.Services.Storage;
+using Microsoft.WindowsAzure.Storage;
 
 namespace NuGet.Services.Work.Jobs
 {
     public class EmitResolverBlobsJob : JobHandler<EmitResolverBlobsEventSource>
     {
-        public EmitResolverBlobsJob(ConfigurationHub config, StorageHub storage)
+        public EmitResolverBlobsJob(ConfigurationHub config)
         {
-            Storage = storage;
             Config = config;
         }
 
         ConfigurationHub Config { get; set; }
-        StorageHub Storage { get; set; }
 
         public string CatalogUri { get; set; }
         //public string ConnectionString { get; set; }
@@ -34,7 +28,7 @@ namespace NuGet.Services.Work.Jobs
         {
             NuGet.Services.Metadata.Catalog.Persistence.Storage storage = new AzureStorage
             {
-                ConnectionString = Storage.Legacy.ConnectionString,
+                ConnectionString = Config.Storage.Legacy.GetConnectionString(),
                 Container = Container,
                 BaseAddress = BaseAddress
             };

--- a/src/NuGet.Services.Work/NuGet.Services.Work.csproj
+++ b/src/NuGet.Services.Work/NuGet.Services.Work.csproj
@@ -43,15 +43,19 @@
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
-    <Reference Include="Dapper">
-      <HintPath>..\..\packages\Dapper.1.13\lib\net45\Dapper.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Dapper.1.25\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="dotNetRDF, Version=1.0.3.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EntityFramework.6.1.1-beta1\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer">
+      <HintPath>..\..\packages\EntityFramework.6.1.1-beta1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+	<Reference Include="dotNetRDF, Version=1.0.3.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\dotNetRDF.1.0.5.3315\lib\net40\dotNetRDF.dll</HintPath>
-    </Reference>
-    <Reference Include="EntityFramework">
-      <HintPath>..\..\packages\EntityFramework.5.0.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.6.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -100,14 +104,17 @@
     <Reference Include="Lucene.Net.Store.Azure">
       <HintPath>..\..\packages\Lucene.Net.Store.Azure.2.0.4937.26631\lib\net40\Lucene.Net.Store.Azure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.1\lib\net40\Microsoft.Data.Edm.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.1\lib\net40\Microsoft.Data.OData.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.1\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -133,11 +140,16 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -145,11 +157,11 @@
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.1\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
@@ -157,8 +169,9 @@
     <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Management.Sql">
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql.0.9.14-preview\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Management.Sql, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql.1.2.0\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>False</Private>
@@ -179,19 +192,20 @@
       <HintPath>..\..\packages\NuGet.Indexing.3.0.29-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Services.Metadata.Catalog, Version=3.0.27.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Services.Metadata.Catalog.3.0.27-r-master\lib\net45\NuGet.Services.Metadata.Catalog.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.23-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.23-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
-    <Reference Include="NuGetGallery.Core">
-      <HintPath>..\..\packages\NuGetGallery.Core.3.0.4-r-master\lib\net45\NuGetGallery.Core.dll</HintPath>
+    <Reference Include="NuGetGallery.Core, Version=3.0.80.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NuGetGallery.Core.3.0.80-r-master\lib\net45\NuGetGallery.Core.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -199,20 +213,21 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Data.Entity" />
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.2.0-rc\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.23.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.23-beta\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -227,23 +242,27 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\..\packages\Rx-PlatformServices.2.2.4\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Spatial.5.6.0\lib\net40\System.Spatial.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.14.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="System.Spatial, Version=5.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.14\lib\portable-net45+win8\System.Threading.Tasks.Dataflow.dll</HintPath>
+      <HintPath>..\..\packages\System.Spatial.5.6.1\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Dataflow, Version=4.5.22.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.22-beta\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Http, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.0-rc\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="System.Web.Http.Owin, Version=5.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.2.0-rc\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -380,11 +399,6 @@
     <EmbeddedResource Include="Jobs\Scripts\MetadataEventStream_CreateLogTables.sql" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
@@ -393,6 +407,11 @@
     <Error Condition="!Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets'))" />
   </Target>
   <Import Project="..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets" Condition="Exists('..\..\packages\NuGet.Services.Build.3.0.5\build\NuGet.Services.Build.targets')" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.17-beta\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NuGet.Services.Work/NuGet.Services.Work.csproj
+++ b/src/NuGet.Services.Work/NuGet.Services.Work.csproj
@@ -36,8 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Autofac">
-      <HintPath>..\..\packages\Autofac.3.3.0\lib\net40\Autofac.dll</HintPath>
+    <Reference Include="Autofac, Version=3.5.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Autofac.3.5.0\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
@@ -124,11 +125,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Security.3.0.0-beta1\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.0.1304.0\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure">
-      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.WindowsAzure.1.1.1403.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.WindowsAzure.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.dll</HintPath>
@@ -136,27 +139,28 @@
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\net45\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.1.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Common.NetFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.0.3\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.WindowsAzure.Common.1.1.0\lib\net45\Microsoft.WindowsAzure.Common.NetFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="Microsoft.WindowsAzure.Diagnostics, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Management.Sql">
       <HintPath>..\..\packages\Microsoft.WindowsAzure.Management.Sql.0.9.14-preview\lib\net40\Microsoft.WindowsAzure.Management.Sql.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -167,9 +171,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.50320.36, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.8.50506.491, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.1\lib\net40-Client\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Indexing">
       <HintPath>..\..\packages\NuGet.Indexing.3.0.29-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
@@ -178,13 +182,13 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Services.Metadata.Catalog.3.0.27-r-master\lib\net45\NuGet.Services.Metadata.Catalog.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.16-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.3.0.20-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.16.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Services.Platform.Client, Version=3.0.20.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.16-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Services.Platform.Client.3.0.20-r-master\lib\portable-net45+wp80+win\NuGet.Services.Platform.Client.dll</HintPath>
     </Reference>
     <Reference Include="NuGetGallery.Core">
       <HintPath>..\..\packages\NuGetGallery.Core.3.0.4-r-master\lib\net45\NuGetGallery.Core.dll</HintPath>
@@ -205,20 +209,23 @@
     </Reference>
     <Reference Include="System.Net.Http.Formatting, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.1\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Client.5.1.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.Primitives">
       <HintPath>..\..\packages\Microsoft.Net.Http.2.2.18\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="System.Reactive.Core">
-      <HintPath>..\..\packages\Rx-Core.2.2.2\lib\net45\System.Reactive.Core.dll</HintPath>
+    <Reference Include="System.Reactive.Core, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Core.2.2.4\lib\net45\System.Reactive.Core.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Interfaces">
-      <HintPath>..\..\packages\Rx-Interfaces.2.2.2\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    <Reference Include="System.Reactive.Interfaces, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Interfaces.2.2.4\lib\net45\System.Reactive.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reactive.Linq">
-      <HintPath>..\..\packages\Rx-Linq.2.2.2\lib\net45\System.Reactive.Linq.dll</HintPath>
+    <Reference Include="System.Reactive.Linq, Version=2.2.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Rx-Linq.2.2.4\lib\net45\System.Reactive.Linq.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
@@ -232,10 +239,11 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.1\lib\net45\System.Web.Http.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Owin">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.1\lib\net45\System.Web.Http.Owin.dll</HintPath>
+    <Reference Include="System.Web.Http.Owin, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Owin.5.1.2\lib\net45\System.Web.Http.Owin.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/NuGet.Services.Work/NuGet.Services.Work.csproj
+++ b/src/NuGet.Services.Work/NuGet.Services.Work.csproj
@@ -43,6 +43,7 @@
     <Reference Include="Autofac.Integration.WebApi">
       <HintPath>..\..\packages\Autofac.WebApi5.3.0.0-rc1\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
+    <Reference Include="Dapper, Version=1.25.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Dapper.1.25\lib\net45\Dapper.dll</HintPath>
     </Reference>
@@ -53,7 +54,7 @@
     <Reference Include="EntityFramework.SqlServer">
       <HintPath>..\..\packages\EntityFramework.6.1.1-beta1\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
-	<Reference Include="dotNetRDF, Version=1.0.3.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
+    <Reference Include="dotNetRDF, Version=1.0.3.0, Culture=neutral, PublicKeyToken=6055ffe4c97cc780, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\dotNetRDF.1.0.5.3315\lib\net40\dotNetRDF.dll</HintPath>
     </Reference>
@@ -188,14 +189,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Core.2.8.2\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Indexing">
-      <HintPath>..\..\packages\NuGet.Indexing.3.0.29-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Services.Metadata.Catalog, Version=3.0.27.0, Culture=neutral, processorArchitecture=MSIL">
-    <Reference Include="NuGet.Services.Platform, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Indexing, Version=3.0.31.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Services.Metadata.Catalog.3.0.27-r-master\lib\net45\NuGet.Services.Metadata.Catalog.dll</HintPath>
+      <HintPath>..\..\packages\NuGet.Indexing.3.0.31-r-master\lib\net45\NuGet.Indexing.dll</HintPath>
     </Reference>
+    <Reference Include="NuGet.Services.Metadata.Catalog">
+      <HintPath>..\..\packages\NuGet.Services.Metadata.Catalog.3.0.30-r-master\lib\net45\NuGet.Services.Metadata.Catalog.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Services.Platform, Version=3.0.23.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NuGet.Services.Platform.3.0.23-r-master\lib\net45\NuGet.Services.Platform.dll</HintPath>
     </Reference>

--- a/src/NuGet.Services.Work/WorkService.cs
+++ b/src/NuGet.Services.Work/WorkService.cs
@@ -1,44 +1,24 @@
 ﻿using System;
 using System.Reactive.Linq;
 using System.Collections.Generic;
-using System.Diagnostics.Tracing;
-using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
-using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Formatters;
-using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
-using Microsoft.WindowsAzure.Diagnostics;
-using Microsoft.WindowsAzure.ServiceRuntime;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Table;
-using System.Reactive.Subjects;
-using System.Reactive.Disposables;
-using Microsoft.WindowsAzure.Storage.Blob;
 using NuGet.Services.Work.Monitoring;
-using System.Net;
-using NuGet.Services.Storage;
 using NuGet.Services.Work.Configuration;
-using Autofac.Core;
 using Autofac;
 using NuGet.Services.ServiceModel;
-using NuGet.Services.Work.Api.Models;
 using NuGet.Services.Configuration;
 using NuGet.Services.Work.Models;
-using System.Threading;
 using System.Diagnostics;
-using Autofac.Features.ResolveAnything;
 using NuGet.Services.Http;
 using Microsoft.Owin;
 using System.Web.Http.Routing;
-using NuGet.Services.Work.Azure;
 
 namespace NuGet.Services.Work
 {
     public class WorkService : NuGetApiService
     {
-        internal const string InvocationLogsContainerBaseName = "ng-work-invocations";
+        internal const string InvocationLogsContainerName = "ng-work-invocations";
         public static readonly int DefaultWorkersPerCore = 2;
         private static readonly PathString _basePath = new PathString("/work");
 
@@ -156,7 +136,6 @@ namespace NuGet.Services.Work
                     .UsingConstructor(
                         typeof(Clock),
                         typeof(string),
-                        typeof(StorageHub),
                         typeof(ConfigurationHub))
                     .WithParameter(
                         new NamedParameter("instanceName", ServiceName.ToString() + "#api"));

--- a/src/NuGet.Services.Work/app.config
+++ b/src/NuGet.Services.Work/app.config
@@ -1,80 +1,46 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-  </configSections>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.18.0" newVersion="4.2.18.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.8.50320.36" newVersion="2.8.50320.36" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Reactive.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.0.0" newVersion="2.2.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.XmlTransform" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.0.0" newVersion="1.2.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="Neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.6.0.0" newVersion="5.6.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="Neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="Neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-  <entityFramework>
-    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
-      <parameters>
-        <parameter value="v11.0" />
-      </parameters>
-    </defaultConnectionFactory>
-  </entityFramework>
+    <configSections>
+        <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+        <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    </configSections>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+			<dependentAssembly>
+				<assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="NuGet.Core" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+			</dependentAssembly>
+			<dependentAssembly>
+				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
+			</dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <entityFramework>
+        <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+            <parameters>
+                <parameter value="v11.0"/>
+            </parameters>
+        </defaultConnectionFactory>
+    </entityFramework>
 </configuration>

--- a/src/NuGet.Services.Work/app.config
+++ b/src/NuGet.Services.Work/app.config
@@ -1,46 +1,125 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
+        <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-        <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
     </configSections>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="NuGet.Core" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-5.1.0.0" newVersion="5.1.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
-			</dependentAssembly>
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
-			</dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Autofac" publicKeyToken="17863AF14B0044DA" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="EntityFramework" publicKeyToken="B77A5C561934E089" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Spatial" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Core" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30AD4FE6B2A6AEED" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Web.Http" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31BF3856AD364E35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.6.1.0" newVersion="5.6.1.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="NuGet.Core" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-2.8.50506.491" newVersion="2.8.50506.491" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="EntityFramework" publicKeyToken="b77a5c561934e089" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.2.23.0" newVersion="4.2.23.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+            </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <entityFramework>
         <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
             <parameters>
-                <parameter value="v11.0"/>
+                <parameter value="v11.0" />
             </parameters>
         </defaultConnectionFactory>
+        <providers>
+            <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+        </providers>
     </entityFramework>
 </configuration>

--- a/src/NuGet.Services.Work/packages.config
+++ b/src/NuGet.Services.Work/packages.config
@@ -3,12 +3,12 @@
   <package id="Autofac" version="3.5.0" targetFramework="net45" />
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
   <package id="Dapper" version="1.25" targetFramework="net45" />
+  <package id="dotNetRDF" version="1.0.5.3315" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
-  <package id="dotNetRDF" version="1.0.5.3315" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.1-beta1" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="json-ld.net" version="1.0.1" targetFramework="net45" />
-  <package id="EntityFramework" version="6.1.1-beta1" targetFramework="net45" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Store.Azure" version="2.0.4937.26631" targetFramework="net45" />
@@ -31,17 +31,16 @@
   <package id="Microsoft.WindowsAzure.Common" version="1.1.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Management.Sql" version="1.2.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
-  <package id="NuGet.Indexing" version="3.0.19-r-master" targetFramework="net45" />
-  <package id="NuGet.Indexing" version="3.0.29-r-master" targetFramework="net45" />
+  <package id="NuGet.Indexing" version="3.0.31-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Metadata.Catalog" version="3.0.27-r-master" targetFramework="net45" />
-  <package id="NuGetGallery.Core" version="3.0.31-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Metadata.Catalog" version="3.0.30-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Platform" version="3.0.23-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Platform.Client" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGetGallery.Core" version="3.0.31-r-master" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.80-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
@@ -50,7 +49,7 @@
   <package id="Rx-Main" version="2.2.4" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
-  <package id="VDS.Common" version="1.3.0" targetFramework="net45" />
   <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
+  <package id="VDS.Common" version="1.3.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Services.Work/packages.config
+++ b/src/NuGet.Services.Work/packages.config
@@ -2,54 +2,55 @@
 <packages>
   <package id="Autofac" version="3.5.0" targetFramework="net45" />
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
-  <package id="Dapper" version="1.13" targetFramework="net45" />
+  <package id="Dapper" version="1.25" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
   <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
   <package id="dotNetRDF" version="1.0.5.3315" targetFramework="net45" />
-  <package id="EntityFramework" version="5.0.0" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="json-ld.net" version="1.0.1" targetFramework="net45" />
+  <package id="EntityFramework" version="6.1.1-beta1" targetFramework="net45" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Store.Azure" version="2.0.4937.26631" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
-  <package id="Microsoft.Data.Edm" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.OData" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.0" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.18" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.0-rc" targetFramework="net45" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.17-beta" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.1" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.23-beta" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
-  <package id="Microsoft.Tpl.Dataflow" version="4.5.14" targetFramework="net45" />
+  <package id="Microsoft.Tpl.Dataflow" version="4.5.22-beta" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.1" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Management.Sql" version="0.9.14-preview" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Management.Sql" version="1.2.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.19-r-master" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.29-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
-  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Metadata.Catalog" version="3.0.27-r-master" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.31-r-master" targetFramework="net45" />
-  <package id="NuGetGallery.Core" version="3.0.4-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.23-r-master" targetFramework="net45" />
+  <package id="NuGetGallery.Core" version="3.0.80-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
-  <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
+  <package id="Rx-Main" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-PlatformServices" version="2.2.4" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />
-  <package id="System.Spatial" version="5.6.0" targetFramework="net45" />
   <package id="VDS.Common" version="1.3.0" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.1" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="4.0.1" targetFramework="net45" />
 </packages>

--- a/src/NuGet.Services.Work/packages.config
+++ b/src/NuGet.Services.Work/packages.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.3.0" targetFramework="net45" />
+  <package id="Autofac" version="3.5.0" targetFramework="net45" />
   <package id="Autofac.WebApi5" version="3.0.0-rc1" targetFramework="net45" />
   <package id="Dapper" version="1.13" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging" version="1.1.1403.1" targetFramework="net45" />
+  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.1.1403.1" targetFramework="net45" />
   <package id="dotNetRDF" version="1.0.5.3315" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging" version="1.0.1304.0" targetFramework="net45" />
-  <package id="EnterpriseLibrary.SemanticLogging.WindowsAzure" version="1.0.1304.1" targetFramework="net45" />
   <package id="EntityFramework" version="5.0.0" targetFramework="net45" />
   <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net45" />
   <package id="json-ld.net" version="1.0.1" targetFramework="net45" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Contrib" version="3.0.3" targetFramework="net45" />
   <package id="Lucene.Net.Store.Azure" version="2.0.4937.26631" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.1" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.6" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
@@ -27,25 +27,25 @@
   <package id="Microsoft.Owin.Hosting" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0-beta1" targetFramework="net45" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.14" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
-  <package id="Microsoft.WindowsAzure.Common" version="1.0.3" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
+  <package id="Microsoft.WindowsAzure.Common" version="1.1.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Common.Dependencies" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.Management.Sql" version="0.9.14-preview" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
-  <package id="NuGet.Core" version="2.8.1" targetFramework="net45" />
+  <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.19-r-master" targetFramework="net45" />
   <package id="NuGet.Indexing" version="3.0.29-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Build" version="3.0.5" targetFramework="net45" developmentDependency="true" />
+  <package id="NuGet.Services.Platform" version="3.0.20-r-master" targetFramework="net45" />
+  <package id="NuGet.Services.Platform.Client" version="3.0.20-r-master" targetFramework="net45" />
   <package id="NuGet.Services.Metadata.Catalog" version="3.0.27-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform" version="3.0.16-r-master" targetFramework="net45" />
-  <package id="NuGet.Services.Platform.Client" version="3.0.16-r-master" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.31-r-master" targetFramework="net45" />
   <package id="NuGetGallery.Core" version="3.0.4-r-master" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="Rx-Core" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Interfaces" version="2.2.2" targetFramework="net45" />
-  <package id="Rx-Linq" version="2.2.2" targetFramework="net45" />
+  <package id="Rx-Core" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Interfaces" version="2.2.4" targetFramework="net45" />
+  <package id="Rx-Linq" version="2.2.4" targetFramework="net45" />
   <package id="Rx-Main" version="2.2.2" targetFramework="net45" />
   <package id="Rx-PlatformServices" version="2.2.2" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net45" />


### PR DESCRIPTION
The latest service platform replaced StorageHub with extension methods on CloudBlobContainer and friends because StorageHub was a useless and leaky abstraction. This updates the Work Service to remove dependence on that abstraction.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/nuget/nuget.services.work/35)

<!-- Reviewable:end -->
